### PR TITLE
Rule enhancements

### DIFF
--- a/lib/battle.ex
+++ b/lib/battle.ex
@@ -11,13 +11,13 @@ defmodule Battle do
   4. The armies are adjusted. **
   5. Repeat 1-4 until no armies remain for one of the sides.
 
-  * ROLL RULES:
+  ## ROLL RULES:
 
    * The attacker rolls 3 dice if the army count is 3 or above, else the number of armies get a die:
      2 armies, 2 dice, 1 army, 1 die and so on.
    * The defender rolls 2 dice if the army count is 2 or above, otherwise rolls 1 die.
 
-  ** ADJUSTMENT RULES:
+  ## ADJUSTMENT RULES:
 
   For each pair of dice,
 
@@ -45,7 +45,13 @@ defmodule Battle do
 
   def evaluate!(a, d), do: if(a > d, do: {0, -1}, else: {-1, 0})
 
-  def evaluate({a, d}) do
+  def evaluate(dice, options \\ []) do
+    dice
+    |> Enhancement.add_benefit(options)
+    |> Enhancement.add_dice_bonus(options)
+
+    {a, d} = dice
+
     Enum.zip(a, d)
     |> Enum.map(fn {a, d} -> evaluate!(a, d) end)
     |> Enum.unzip()
@@ -63,15 +69,17 @@ defmodule Battle do
     |> List.to_tuple()
   end
 
-  def combat({remaining, lost}) when lost <= 0, do: {:victory, remaining}
+  def combat(troops, options \\ [])
 
-  def combat({lost, remaining}) when lost <= 0, do: {:defeat, remaining}
+  def combat({remaining, lost}, _options) when lost <= 0, do: {:victory, remaining}
 
-  def combat(troops) do
+  def combat({lost, remaining}, _options) when lost <= 0, do: {:defeat, remaining}
+
+  def combat(troops, options) do
     troops
     |> roll
-    |> evaluate
+    |> evaluate(options)
     |> adjust(troops)
-    |> combat
+    |> combat(options)
   end
 end

--- a/lib/enhancement.ex
+++ b/lib/enhancement.ex
@@ -1,0 +1,145 @@
+defmodule Enhancement do
+  @moduledoc """
+  Several enhancement exists in the Battle game.
+
+  DICE BONUS
+
+  In some cases a dice bonus is applied.
+
+   * A *hero* may join the attacking troops. It should not count as a troop, but will apply +1 to the highest die
+     each time the troops attack.
+   * The defending troops may defend a *fort*. The fort applies +1 to the highest die each time the troops defend.
+
+  STRATEGIC BENEFIT
+
+  In some cases a strategic benefit is applied.
+
+   * If the attacking troops' dice are overwhelming, the defending troops can choose to only defend with 1 die, and
+     only risk losing 1 troop instead of losing 2 (in case of several dice).
+  """
+
+  @has_hero "has_hero"
+  @is_fort "is_fort"
+  @can_use_1_die "can_use_1_die"
+
+  @doc """
+  Add +1 to the first item in a list of integers (dice).
+
+  ## Examples
+
+    iex> Enhancement.plus1([4, 3])
+    [5, 3]
+    iex> Enhancement.plus1([2])
+    [3]
+    iex> Enhancement.plus1([2, 1, 1])
+    [3, 1, 1]
+
+  """
+  def plus1(dice) do
+    [head | tail] = dice
+    [head + 1 | tail]
+  end
+
+  @doc """
+  Applies +1 to highest die if the defending troops defends a fortification.
+
+  ## Examples
+
+    iex> Enhancement.fort_bonus({[4, 3], [4, 3]}, true)
+    {[4, 3], [5, 3]}
+
+    iex> Enhancement.fort_bonus({[4], [4]}, true)
+    {[4], [5]}
+
+    iex> Enhancement.fort_bonus({[4, 3], [4, 3]}, false)
+    {[4, 3], [4, 3]}
+
+    iex> Enhancement.fort_bonus({[4], [4]}, false)
+    {[4], [4]}
+  """
+  def fort_bonus(dice, is_fort?) when not is_fort?, do: dice
+
+  def fort_bonus(dice, is_fort?) when is_fort? do
+    {a, d} = dice
+    {a, plus1(d)}
+  end
+
+  @doc """
+  Applies +1 to highest attacking die if the attacking troops has a hero.
+
+  ## Examples
+
+    iex> Enhancement.hero_bonus({[6, 4, 3], [4, 3]}, true)
+    {[7, 4, 3], [4, 3]}
+
+    iex> Enhancement.hero_bonus({[4, 3], [4, 3]}, true)
+    {[5, 3], [4, 3]}
+
+    iex> Enhancement.hero_bonus({[4], [4]}, true)
+    {[5], [4]}
+
+    iex> Enhancement.hero_bonus({[6, 4, 3], [4, 3]}, false)
+    {[6, 4, 3], [4, 3]}
+
+    iex> Enhancement.hero_bonus({[4, 3], [4, 3]}, false)
+    {[4, 3], [4, 3]}
+
+    iex> Enhancement.hero_bonus({[4], [4]}, false)
+    {[4], [4]}
+
+  """
+  def hero_bonus(dice, has_hero?) when not has_hero?, do: dice
+
+  def hero_bonus(dice, has_hero?) when has_hero? do
+    {a, d} = dice
+    {plus1(a), d}
+  end
+
+  @doc """
+  Removes 1 defending die of the attacking dice are to good (has the sum 10 or higher).
+
+  ## Examples
+
+    iex> Enhancement.strong_offence_benefit({[6, 4, 3], [3, 3]}, true)
+    {[6, 4, 3], [3]}
+
+    iex> Enhancement.strong_offence_benefit({[6, 5], [3, 3]}, true)
+    {[6, 5], [3]}
+
+    iex> Enhancement.strong_offence_benefit({[4], [4]}, true)
+    {[4], [4]}
+
+    iex> Enhancement.strong_offence_benefit({[6, 4, 3], [3, 3]}, false)
+    {[6, 4, 3], [3, 3]}
+
+    iex> Enhancement.strong_offence_benefit({[6, 5], [3, 3]}, false)
+    {[6, 5], [3, 3]}
+
+    iex> Enhancement.strong_offence_benefit({[4], [4]}, false)
+    {[4], [4]}
+
+  """
+  def strong_offence_benefit(dice = {[_], _}, _can_use_1_die?), do: dice
+
+  def strong_offence_benefit(dice, can_use_1_die?) when not can_use_1_die?, do: dice
+
+  def strong_offence_benefit(dice = {[highest, near_highest | tail], d}, can_use_1_die?)
+      when can_use_1_die? do
+    if highest + near_highest > 9 do
+      {[highest, near_highest | tail], Enum.random(d) |> List.wrap()}
+    else
+      dice
+    end
+  end
+
+  def add_dice_bonus(dice, options \\ []) do
+    dice
+    |> fort_bonus(@is_fort in options)
+    |> hero_bonus(@has_hero in options)
+  end
+
+  def add_benefit(dice, options \\ []) do
+    dice
+    |> strong_offence_benefit(@can_use_1_die in options)
+  end
+end

--- a/lib/risk_dice.ex
+++ b/lib/risk_dice.ex
@@ -6,10 +6,18 @@ defmodule RiskDice do
   @doc """
   Simulate a RISK battle for `attacking_troops` attacking `defending_troops`, for `num` times. Let `num` be a
   *high* number.
+
+  `options` is an optional list of strings, containing any of the following:
+
+  * `is_fort` - +1 on the highest die for the defending troops
+  * `has_hero` - +1 on the highest die for the attacking troops
+  * `can_use_1_die` - Allows the defender to use 1 die instead of 2 dice when
+    the attacking troop's dice are to good (6,6, 6,5, 6,4 or 5,5)
+
   """
-  def simulate(attacking_troops, defending_troops, num) do
+  def simulate(attacking_troops, defending_troops, num, options \\ []) do
     1..num
-    |> Enum.map(fn _ -> Battle.combat({attacking_troops, defending_troops}) end)
+    |> Enum.map(fn _ -> Battle.combat({attacking_troops, defending_troops}, options) end)
     |> Summary.create()
   end
 end

--- a/test/enhancement_test.exs
+++ b/test/enhancement_test.exs
@@ -1,0 +1,4 @@
+defmodule EnhancementTest do
+  use ExUnit.Case
+  doctest Enhancement
+end


### PR DESCRIPTION
This module adds 2 dice bonuses, and 1 strategical benefit.

 * *Dice bonus*: If the attacking troops has a hero, the highest die will have a +1 bonus.
 * *Dice bonus*: If the defending troops is in a fort, the highest die will have a +1 bonus.
 * *Strategical benefit*: If the attacking dice has a sum of 10 or above, the defender will choose to only defend with 1 die, hence only risk losing 1 troop instead of 2.

Experimenting with doctests here.